### PR TITLE
feat: Add staff child selection and schedule management

### DIFF
--- a/src/components/ChildSelector.tsx
+++ b/src/components/ChildSelector.tsx
@@ -31,7 +31,8 @@ export function ChildSelector({
         value={selectedChildId}
         onChange={onChildSelect}
         disabled={disabled || children.length === 0}
-        suffixIcon={<UserOutlined />}>
+        suffixIcon={<UserOutlined />}
+        allowClear>
         {children.map(child => (
           <Select.Option key={child.id} value={child.id}>
             <Space style={{ direction: "rtl" }}>

--- a/src/contexts/ChildContext.tsx
+++ b/src/contexts/ChildContext.tsx
@@ -4,8 +4,8 @@ import { useAuth } from "./AuthContext";
 import type { Child } from "../types";
 
 interface ChildContextType {
-  selectedChild: Child | null;
-  setSelectedChild: (child: Child | null) => void;
+  selectedChild: Child | undefined;
+  setSelectedChild: (child: Child | undefined) => void;
   children: Child[];
   loading: boolean;
   error: string | null;
@@ -18,7 +18,9 @@ export function ChildProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [selectedChild, setSelectedChild] = useState<Child | null>(null);
+  const [selectedChild, setSelectedChild] = useState<Child | undefined>(
+    undefined
+  );
   const { hasRole } = useAuth();
   const { children, loading, error } = useChildren();
   const isParent = hasRole("parent");
@@ -33,7 +35,7 @@ export function ChildProvider({
   // Clear selected child if user is not a parent
   useEffect(() => {
     if (!isParent && selectedChild) {
-      setSelectedChild(null);
+      setSelectedChild(undefined);
     }
   }, [isParent, selectedChild]);
 
@@ -43,7 +45,7 @@ export function ChildProvider({
       selectedChild &&
       !children.find(child => child.id === selectedChild.id)
     ) {
-      setSelectedChild(null);
+      setSelectedChild(undefined);
     }
   }, [children, selectedChild]);
 

--- a/src/hooks/useAllChildren.ts
+++ b/src/hooks/useAllChildren.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { childrenApi } from "../services/api";
+import type { Child } from "../types";
+
+export function useAllChildren() {
+  const [children, setChildren] = useState<Child[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadAllChildren = async () => {
+      try {
+        const childrenData = await childrenApi.getAllChildren();
+        if (mounted) {
+          setChildren(childrenData);
+          setError(null);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load children"
+          );
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadAllChildren();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return {
+    children,
+    loading,
+    error,
+  };
+}

--- a/src/hooks/useChildSchedule.ts
+++ b/src/hooks/useChildSchedule.ts
@@ -1,16 +1,22 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "../contexts/AuthContext";
 import { scheduleApi } from "../services/api";
 import type { Child, ScheduleSelectionWithClass } from "../types";
-import { useAuth } from "../contexts/AuthContext";
 
-export function useChildSchedule(child: Child | null) {
+export function useChildSchedule(child: Child | undefined) {
   const [schedule, setSchedule] = useState<ScheduleSelectionWithClass[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { hasRole } = useAuth();
 
+  // Memoize the dependencies to prevent unnecessary re-renders
+  const deps = useMemo(
+    () => [child?.id, hasRole("parent"), hasRole("staff")],
+    [child?.id, hasRole]
+  );
+
   useEffect(() => {
-    if (!child || !hasRole("parent")) {
+    if (!child || (!hasRole("parent") && !hasRole("staff"))) {
       setSchedule([]);
       setLoading(false);
       return;
@@ -44,7 +50,7 @@ export function useChildSchedule(child: Child | null) {
     return () => {
       mounted = false;
     };
-  }, [child?.id, hasRole]);
+  }, deps);
 
   const selectClassForChild = async (classId: string): Promise<void> => {
     if (!child) throw new Error("No child selected");

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -72,13 +72,16 @@
       "roleSelectorPlaceholder": "בחר תפקיד",
       "labels": {
         "selectChild": "בחר ילד",
+        "selectChildForStaff": "בחר תלמיד",
         "filterByGrade": "סנן לפי כיתה",
         "searchClass": "חיפוש שיעור"
       },
       "placeholders": {
         "allGrades": "כל הכיתות",
         "searchClass": "הקלד שם שיעור לחיפוש...",
-        "selectRole": "בחר תפקיד"
+        "selectRole": "בחר תפקיד",
+        "selectChildForStaff": "בחר תלמיד...",
+        "classFilterDisabled": "חיפוש מבוטל - נבחר תלמיד"
       },
       "childSelectorLabel": "בחר ילד:",
       "gradeFilterLabel": "סנן לפי כיתה:",

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -17,12 +17,13 @@ import { useAuth } from "../contexts/AuthContext";
 import { useChildContext } from "../contexts/ChildContext";
 import { useSchedule } from "../hooks/useSchedule";
 import { useChildSchedule } from "../hooks/useChildSchedule";
+import { useAllChildren } from "../hooks/useAllChildren";
 import ScheduleTable from "../components/ScheduleTable";
 import ClassForm from "../components/ClassForm";
 import { ChildSelector } from "../components/ChildSelector";
 import { classesApi, timeSlotsApi } from "../services/api";
 import { GRADES } from "../types";
-import type { AppOnNavigate, Class, TimeSlot } from "../types";
+import type { AppOnNavigate, Class, TimeSlot, Child } from "../types";
 import "./SchedulePage.css";
 import { GetGradeName } from "@/utils/grades";
 
@@ -50,6 +51,14 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
     error: childrenError,
   } = useChildContext();
 
+  // For staff users - get all children and manage separate selected child state
+  const { children: allChildren, loading: allChildrenLoading } =
+    useAllChildren();
+  const [staffSelectedChild, setStaffSelectedChild] = useState<
+    Child | undefined
+  >(undefined);
+  const isStaff = hasRole("staff");
+
   const [selectedGrade, setSelectedGrade] = useState<number | undefined>(1);
   const [createClassModalOpen, setCreateClassModalOpen] = useState(false);
   const [createClassTimeSlotId, setCreateClassTimeSlotId] = useState<
@@ -63,6 +72,21 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
   const [searchTerm, setSearchTerm] = useState<string>("");
 
   const isParent = hasRole("parent");
+
+  const handleStaffChildSelect = (childId: string) => {
+    if (!childId) {
+      setStaffSelectedChild(undefined);
+      return;
+    }
+    const child = allChildren.find(c => c.id === childId);
+    if (child) {
+      // Use React's batching by updating states together
+      setStaffSelectedChild(child);
+      setSelectedGrade(child.grade);
+    } else {
+      setStaffSelectedChild(undefined);
+    }
+  };
 
   // Auto-update grade filter when selected child changes (only for non-admin parents)
   React.useEffect(() => {
@@ -92,11 +116,13 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
     selectClassForChild,
     unselectClassForChild,
     isClassSelected: isChildClassSelected,
-  } = useChildSchedule(selectedChild);
+  } = useChildSchedule(isStaff ? staffSelectedChild : selectedChild);
 
   const loading = isParent
     ? scheduleLoading || childScheduleLoading || childrenLoading
-    : scheduleLoading;
+    : isStaff
+      ? scheduleLoading || childScheduleLoading || allChildrenLoading
+      : scheduleLoading;
   const error = scheduleError || childScheduleError || childrenError;
 
   const handleRoleSwitch = (roleId: string) => {
@@ -131,13 +157,17 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
   };
 
   const getSelectedClasses = () => {
-    return isParent
-      ? childSchedule.map(selection => selection.classId)
-      : userSelections.map(selection => selection.classId);
+    if (isParent || (isStaff && staffSelectedChild)) {
+      return childSchedule.map(selection => selection.classId);
+    }
+    return userSelections.map(selection => selection.classId);
   };
 
   const getSelectedSchedule = () => {
-    return isParent ? childSchedule : userSelections;
+    if (isParent || (isStaff && staffSelectedChild)) {
+      return childSchedule;
+    }
+    return userSelections;
   };
 
   const handleCreateClass = async (timeSlotId: string, dayOfWeek: number) => {
@@ -196,8 +226,9 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
 
   const selectedClasses = getSelectedClasses();
   const canSelectClasses =
-    (currentRole?.role === "child" || currentRole?.role === "parent") &&
-    (!isParent || selectedChild !== null);
+    ((currentRole?.role === "child" || currentRole?.role === "parent") &&
+      (!isParent || selectedChild !== null)) ||
+    (isStaff && staffSelectedChild !== null);
 
   const canViewClasses =
     canSelectClasses ||
@@ -230,12 +261,19 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
                   new Set(
                     classes
                       .filter(cls => {
-                        // Apply grade filter if set
-                        if (
-                          selectedGrade &&
-                          !cls.grades?.includes(selectedGrade)
-                        ) {
-                          return false;
+                        // For staff with selected child, filter by child's grade only
+                        if (isStaff && staffSelectedChild) {
+                          if (!cls.grades?.includes(staffSelectedChild.grade)) {
+                            return false;
+                          }
+                        } else {
+                          // Apply grade filter if set
+                          if (
+                            selectedGrade &&
+                            !cls.grades?.includes(selectedGrade)
+                          ) {
+                            return false;
+                          }
                         }
                         // Apply class name filter
                         return cls.title
@@ -261,7 +299,7 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
                   selectedChildId={selectedChild?.id || null}
                   onChildSelect={childId => {
                     const child = userChildren.find(c => c.id === childId);
-                    setSelectedChild(child || null);
+                    setSelectedChild(child || undefined);
                     // Auto-update grade filter based on selected child (only for non-admin parents)
                     if (child && !isAdmin()) {
                       setSelectedGrade(child.grade);
@@ -280,7 +318,8 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
                   onChange={setSelectedGrade}
                   placeholder={t("schedule.page.placeholders.allGrades")}
                   allowClear
-                  style={{ minWidth: 120 }}>
+                  style={{ minWidth: 120 }}
+                  disabled={isStaff && !!staffSelectedChild}>
                   {GRADES.map(grade => (
                     <Option key={grade} value={grade}>
                       {GetGradeName(grade)}
@@ -288,6 +327,21 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
                   ))}
                 </Select>
                 <span>{t("schedule.page.labels.filterByGrade")}:</span>
+              </>
+            )}
+            {isStaff && (
+              <>
+                <ChildSelector
+                  children={allChildren}
+                  selectedChildId={staffSelectedChild?.id || null}
+                  onChildSelect={handleStaffChildSelect}
+                  style={{ minWidth: 200 }}
+                  disabled={allChildrenLoading}
+                  placeholder={t(
+                    "schedule.page.placeholders.selectChildForStaff"
+                  )}
+                />
+                <span>{t("schedule.page.labels.selectChildForStaff")}:</span>
               </>
             )}
           </Space>
@@ -409,10 +463,12 @@ const SchedulePage: React.FC<SchedulePageProps> = ({ onNavigate }) => {
       {canSelectClasses && getSelectedSchedule().length > 0 && (
         <Card
           title={
-            isParent && selectedChild
+            (isParent && selectedChild) || (isStaff && staffSelectedChild)
               ? t("schedule.page.selectedClassesForChild", {
-                  firstName: selectedChild.firstName,
-                  lastName: selectedChild.lastName,
+                  firstName: (isParent ? selectedChild : staffSelectedChild)
+                    ?.firstName,
+                  lastName: (isParent ? selectedChild : staffSelectedChild)
+                    ?.lastName,
                 })
               : t("schedule.page.selectedClassesTitle")
           }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -898,6 +898,25 @@ export const childrenApi = {
     }));
   },
 
+  async getAllChildren(): Promise<Child[]> {
+    const { data, error } = await supabase
+      .from("children")
+      .select("*")
+      .order("first_name", { ascending: true });
+
+    if (error) throw new ApiError(error.message);
+
+    return data.map(child => ({
+      id: child.id,
+      firstName: child.first_name,
+      lastName: child.last_name,
+      grade: child.grade,
+      groupNumber: child.group_number,
+      createdAt: child.created_at,
+      updatedAt: child.updated_at,
+    }));
+  },
+
   async getChildById(childId: string): Promise<Child> {
     const { data, error } = await supabase
       .from("children")


### PR DESCRIPTION
- Add staff ability to select and manage individual child schedules
- Create useAllChildren hook for staff to access all children
- Update RLS policies to allow staff access to schedule_selections
- Add ChildSelector allowClear prop for better UX
- Disable grade filter when staff selects a child
- Filter class search by selected child's grade for staff
- Update child schedule display for both parents and staff
- Add Hebrew translations for staff child selection
- Fix schedule loading states for staff users
- Optimize child selection to prevent full page reloads

🤖 Generated with [Claude Code](https://claude.ai/code)